### PR TITLE
Remove timestamp == 0

### DIFF
--- a/DoNotPullAWirtual.as
+++ b/DoNotPullAWirtual.as
@@ -116,7 +116,7 @@ void Render() {
 
     uint64 now = Time::get_Now();
 
-    if (timestamp == 0 || now >= timestamp) {
+    if (now >= timestamp) {
         timestamp = now + 500;
         overlayColor = randomColor();
         textColor = randomTextColor();


### PR DESCRIPTION
Now is always greater than 0, and as such timestamp == 0 is checked in the other condition just fine.